### PR TITLE
fix: use links to latest doc

### DIFF
--- a/src/pages/development.md
+++ b/src/pages/development.md
@@ -29,4 +29,4 @@ You can post patches to the mailing list or create a new ticket. Or better, [cre
 
 #### More information
 
-There is a [whole chapter about development in the documentation](https://mapproxy.github.io/mapproxy/development.html). It covers most aspects of the MapProxy development including the source code, documentation, tests, etc.
+There is a [whole chapter about development in the documentation](https://mapproxy.github.io/mapproxy/latest/development.html). It covers most aspects of the MapProxy development including the source code, documentation, tests, etc.

--- a/src/pages/download.md
+++ b/src/pages/download.md
@@ -4,7 +4,7 @@ title: Download
 
 MapProxy releases are available from the [PyPI project page of MapProxy](http://pypi.python.org/pypi/MapProxy). There is also [an archive of all official releases](https://pypi.python.org/packages/source/M/MapProxy/), unofficial releases and pre-releases [can be found here](https://mapproxy.org/static/rel/).
 
-However, downloading is often not necessary, because you can install MapProxy with the Python tools `easy_install` or `pip`. Read the [installation instructions](https://mapproxy.github.io/mapproxy/install.html) for more information.
+However, downloading is often not necessary, because you can install MapProxy with the Python tools `easy_install` or `pip`. Read the [installation instructions](https://mapproxy.github.io/mapproxy/latest/install.html) for more information.
 
 There are several ready-to-use docker images for development/testing and production use. Please check the docs for more information.
 


### PR DESCRIPTION
Fixes https://github.com/mapproxy/mapproxy/issues/1031